### PR TITLE
Fix php 8 method signature compatibility

### DIFF
--- a/includes/api_access.php
+++ b/includes/api_access.php
@@ -107,7 +107,7 @@ abstract class Api_Access {
 	}
 	
 	//all endpoints have this
-	public static function index(){
+	public static function index(...$args){
 		// URL: <host>/<base_class>s.json
 		// create the URL array
 		// the host and namespace (agents) is automatic


### PR DESCRIPTION
Update `Api_Access::index()` to accept variable arguments, resolving PHP 8 fatal errors due to method signature incompatibility.

PHP 8 enforces stricter method signature compatibility between parent and child classes. Previously, child classes like `Access_Point_Metrics` had `index()` methods with parameters, while the parent `Api_Access::index()` had none, which resulted in a fatal error in PHP 8. By adding `...$args` to the parent method, all child overrides become compatible.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb85f973-2f61-416a-bbf7-fb9b87170de2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb85f973-2f61-416a-bbf7-fb9b87170de2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update `Api_Access::index()` to `index(...$args)` to align with child method signatures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5624c2a006ebbbe58f911a99b401a97500d57fe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->